### PR TITLE
fix ESCAPE_RE regular expression

### DIFF
--- a/src/solrq/__init__.py
+++ b/src/solrq/__init__.py
@@ -54,7 +54,7 @@ class Value(object):
     """
 
     # note: since we escape spaces there is no need to escape AND, OR, NOT
-    ESCAPE_RE = re.compile(r'(?<!\\)(?P<char>[ &|+\-!(){}[\]*^"~?:])')
+    ESCAPE_RE = re.compile(r'(?<!\\)(?P<char>[ &|+\\\-!(){}[\]*^"~?:])')
     TIMEDELTA_FORMAT = "NOW{days:+d}DAYS{secs:+d}SECONDS{mills:+d}MILLISECONDS"
 
     def __init__(self, raw, safe=False):

--- a/tests/test_squery.py
+++ b/tests/test_squery.py
@@ -192,17 +192,14 @@ def test_proximity():
     # ... but not if marked as safe
     assert str(Proximity("foo bar", 12, safe=True)) == '"foo bar"~12'
 
-    # note: boosting an explicit value has same result as raw string
-    assert str(
-        Proximity(Value("foo bar"), 12)
-    ) == str(
-        Proximity(Value("foo bar", safe=True), 12)
-    ) == '"foo\\ bar"~12'
-
     # note: only marking safe on all stages ensures it will not be escaped
     assert str(
         Proximity(Value("foo bar", safe=True), 12, safe=True)
     ) == '"foo bar"~12'
+
+
+def test_can_escape_special_characters():
+    assert str(Q(foo="\\")) == "foo:\\\\"
 
 
 def test_reprs():


### PR DESCRIPTION
Make it match a single backslash character. Test that it matches a
single backslash. Remove Proximity(Value()): they cannot be equal,
because the space will be escaped in the instanciation of Value, and the
backslash used to escape the space will then be escaped in Proximity.