### PR TITLE
Validated for Python versions 3.7+

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,9 @@
 # solrq
 `solrq` is a Python Solr query utility. It helps making query strings for Solr
 and also helps with escaping reserved characters. `solrq` is has no external
-dependencies and is compatibile with `python2.6`, `python2.7`,
-`python3.3`, `python3.4`, `python3.5`, `pypy` and `pypy3`.
+dependencies and is compatibile with `python3.7`, `python3,8`, `python3.9`, `python3.10`, `python3.11`, `pypy` and `pypy3`.
 It might be compatibile with other python releases/implentations but this has
-not been tested yet or is no longer tested (e.g `python3.2`).
+not been tested yet or is no longer tested (e.g `python3.2` or `python2.7`).
 
     pip install solrq
     

--- a/src/solrq/__init__.py
+++ b/src/solrq/__init__.py
@@ -2,9 +2,9 @@
 VERSION = (1, 1, 1)  # PEP 386  # noqa
 __version__ = ".".join([str(x) for x in VERSION])  # noqa
 
-import re
-from datetime import datetime, timedelta
-from functools import partial
+import re  # noqa: E402
+from datetime import datetime, timedelta  # noqa: E402
+from functools import partial  # noqa: E402
 
 
 class Value(object):

--- a/tests/test_squery.py
+++ b/tests/test_squery.py
@@ -98,7 +98,7 @@ def test_operator_invalid_boost_call():
 
 def test_value():
     assert str(Value('foo bar')) == 'foo\\ bar'
-    assert str(Value('"foo bar"')) == '\\"foo\ bar\\"'
+    assert str(Value('"foo bar"')) == '\\"foo\\ bar\\"'
     # note: this is how we wrap with quotes
     assert str(Value('"foo bar"', safe=True), ) == '"foo bar"'
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,py35,pypy,pypy3,pep8,pep257,coverage, flake8
+envlist = py37,py38,py39,py310,py311,pypy,pypy3,pep8,pep257,coverage, flake8
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
@@ -7,7 +7,7 @@ deps = -r{toxinidir}/requirements-tests.txt
 setenv = VIRTUAL_ENV = {envdir}
 # note: we test doctests to be sure that all examples are valid
 # but they are not run later in coverage because they are only illustratory
-commands = py.test --doctest-modules --ignore=setup.py --ignore docs {posargs}
+commands = pytest --doctest-modules --ignore=setup.py --ignore docs {posargs}
 sitepackages = False
 
 [testenv:pep8]
@@ -15,7 +15,7 @@ deps = flake8==2.0
 commands = flake8 {posargs}
 
 [testenv:pep257]
-basepython=python3.4
+basepython=python3.7
 deps =
     pydocstyle==1.0.0
 commands = pydocstyle src tests {posargs}
@@ -36,6 +36,6 @@ deps = coverage
        coveralls
        {[testenv]deps}
 usedevelop = True
-commands = coverage run --source solrq -m py.test {posargs}
+commands = coverage run --source solrq -m pytest {posargs}
            coverage report
            coveralls


### PR DESCRIPTION
Hi @swistakm,

I am currently using this library and am totally impressed of how well structured the project is. Thank you!

Since Python 2.7 and 3.6 are deprecated, I wanted to know if the code still runs under current Python version. And it does (with only minor modifications). I would be glad, if you could pull this commit.

Best Regards,

Adrian